### PR TITLE
fix version dependent test failure

### DIFF
--- a/psfws/utils.py
+++ b/psfws/utils.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pandas as pd
 from scipy.interpolate import UnivariateSpline, make_interp_spline
-from scipy.integrate import trapz
+from scipy.integrate import trapezoid
 import scipy.stats
 import os
 
@@ -384,7 +384,7 @@ def integrate_in_bins(cn2, h, edges):
         # get Cn2 interpolation at those values of h -- s=0 for no smoothing.
         cn2_i = np.exp(interpolate(h, np.log(cn2), h_i, ddz=False, s=0))
         # numerically integrate to find the J value for this bin
-        J.append(trapz(cn2_i, h_i))
+        J.append(trapezoid(cn2_i, h_i))
     
     # The dh we integrated over was in km, rather than m. Convert that now, so
     # that J has units of m**(1/3) as desired

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.12
 scikit-learn>=0.22.1
 pytest>=3.6
-scipy>=1.11.0
+scipy>=1.7.0
 pandas>=1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.12
 scikit-learn>=0.22.1
 pytest>=3.6
-scipy>=1.2.0
+scipy>=1.11.0
 pandas>=1.0.1

--- a/tests/test_turbulence.py
+++ b/tests/test_turbulence.py
@@ -18,23 +18,23 @@ def test_joint_pdf():
 
 def test_turbulence_draws():
     # first test with no wind correlation for ground layer
-    j_gl_goal = 3.880497137403186e-13
-    j_fa_goal = 1.936532096294314e-13
+    j_gl_goal = 3.88049713e-13
+    j_fa_goal = 1.93653209e-13
     p = psfws.ParameterGenerator(rho_jv=0, seed=460)
     j_fa_res, j_gl_res = p._draw_j()
 
     np.testing.assert_allclose([j_fa_res, j_gl_res], [j_fa_goal, j_gl_goal],
-                               rtol=1.e-12,
+                               rtol=1.e-8,
                                err_msg='error reproducing turbulence integrals')
 
     # second, test with wind correlation for ground layer
     src = 'ecmwf' if len(p.data_fa['u'].iat[0]) > 50 else 'noaa'
     if src == 'noaa':
-        j_gl_goal = 1.4466640614052723e-13
-        j_fa_goal = 3.3034875838653924e-14
+        j_gl_goal = 1.44666406e-13
+        j_fa_goal = 3.30348758e-14
     elif src == 'ecmwf':
         j_gl_goal = 2.23216667e-13
-        j_fa_goal = 6.408088187515762e-13
+        j_fa_goal = 6.40808818-13
         
     p = psfws.ParameterGenerator(rho_jv=.7, seed=2012)
     pt = p.draw_datapoint()
@@ -42,13 +42,13 @@ def test_turbulence_draws():
 
     try:
         np.testing.assert_allclose([j_fa_res, j_gl_res], [j_fa_goal, j_gl_goal],
-                                   rtol=1.e-12,
+                                   rtol=1.e-8,
                                    err_msg='error reproducing turbulence integrals')
     except AssertionError:
         # might be because of a version difference, so test result from numpy < 2 
-        j_gl_goal = 7.676675326677918e-14
+        j_gl_goal = 7.67667532e-14
         np.testing.assert_allclose([j_fa_res, j_gl_res], [j_fa_goal, j_gl_goal],
-                                   rtol=1.e-12,
+                                   rtol=1.e-8,
                                    err_msg='error reproducing turbulence integrals')       
 
 

--- a/tests/test_turbulence.py
+++ b/tests/test_turbulence.py
@@ -34,7 +34,7 @@ def test_turbulence_draws():
         j_fa_goal = 3.30348758e-14
     elif src == 'ecmwf':
         j_gl_goal = 2.23216667e-13
-        j_fa_goal = 6.40808818-13
+        j_fa_goal = 6.40808818e-13
         
     p = psfws.ParameterGenerator(rho_jv=.7, seed=2012)
     pt = p.draw_datapoint()

--- a/tests/test_turbulence.py
+++ b/tests/test_turbulence.py
@@ -33,16 +33,23 @@ def test_turbulence_draws():
         j_gl_goal = 1.4466640614052723e-13
         j_fa_goal = 3.3034875838653924e-14
     elif src == 'ecmwf':
-        j_gl_goal = 7.676675326677918e-14
+        j_gl_goal = 2.23216667e-13
         j_fa_goal = 6.408088187515762e-13
         
     p = psfws.ParameterGenerator(rho_jv=.7, seed=2012)
     pt = p.draw_datapoint()
     j_fa_res, j_gl_res = p._draw_j(pt)
 
-    np.testing.assert_allclose([j_fa_res, j_gl_res], [j_fa_goal, j_gl_goal],
-                               rtol=1.e-12,
-                               err_msg='error reproducing turbulence integrals')
+    try:
+        np.testing.assert_allclose([j_fa_res, j_gl_res], [j_fa_goal, j_gl_goal],
+                                   rtol=1.e-12,
+                                   err_msg='error reproducing turbulence integrals')
+    except AssertionError:
+        # might be because of a version difference, so test result from numpy < 2 
+        j_gl_goal = 7.676675326677918e-14
+        np.testing.assert_allclose([j_fa_res, j_gl_res], [j_fa_goal, j_gl_goal],
+                                   rtol=1.e-12,
+                                   err_msg='error reproducing turbulence integrals')       
 
 
 def test_turbulence_integration():


### PR DESCRIPTION
numpy 2.0 changed sorting methods that pandas used in their sort_values function. Added the value from this new version as a valid output.